### PR TITLE
Add 3 news flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,23 @@ $isAllowed = $env->allowedValues('key1', ['value1', NULL, 'value2']);
 ```
 
 ### Complete and Override values
+You have 3 differents flags:
+* Environment::GETENV
+* Environment::ENV
+* Environment::SERVER
+
 Complete is for filling values belong to keys having empty string or no values.  
 Override is for erasing values belong to keys.  
 The treatment given by the flags is always in the same order:
 1. `getenv()`
 2. `$_ENV`
 3. `$_SERVER`
+
+You can also use 3 others flags.  
+Those will inject all keys and values found, your env file is not used for checkings keys.
+* Environment::GETENV_ALL
+* Environment::ENV_ALL
+* Environment::SERVER_ALL
 
 ```php
 $env = new Environment(__DIR__);
@@ -141,14 +152,14 @@ $env = new Environment([__DIR__, '/usr'], 'dev.env');
 ## Environment Constructor
 ### Settings
 #### Mandatory
-| Parameter | Type | Description |
-| --- | --- | --- |
-| folder | string OR array | folder to seek .env file |
+| Parameter | Type            | Description              |
+| --------- | --------------- | ------------------------ |
+| folder    | string OR array | folder to seek .env file |
 
 #### Optionnals
-| Parameter | Type | Default value | Description |
-| --- | --- | --- | --- |
-| filename | string | .env | custom name of .env file (don't forget to add file extension) |
+| Parameter | Type   | Default value | Description                                                   |
+| --------- | ------ | ------------- | ------------------------------------------------------------- |
+| filename  | string | .env          | custom name of .env file (don't forget to add file extension) |
 
 ## Environment Methods
 ### General Commands  

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,5 +12,6 @@
   </testsuites>
   <php>
     <env name="TRAVIS" value="alpha"/>
+    <env name="GITHUB" value="omega"/>
   </php>
 </phpunit>

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -9,9 +9,13 @@ namespace Rancoud\Environment;
  */
 class Environment
 {
-    public const GETENV = 0x1;
-    public const ENV = 0x2;
-    public const SERVER = 0x4;
+    public const GETENV = 0x01;
+    public const ENV = 0x02;
+    public const SERVER = 0x04;
+
+    public const GETENV_ALL = 0x08;
+    public const ENV_ALL = 0x10;
+    public const SERVER_ALL = 0x20;
 
     protected array $env = [];
 
@@ -480,6 +484,36 @@ class Environment
                 }
             }
         }
+
+        if ($flags & static::GETENV_ALL) {
+            foreach (\getenv() as $k => $v) {
+                if (array_key_exists($k, $this->env) && $this->env[$k] !== '') {
+                    continue;
+                }
+
+                $this->set($k, $v);
+            }
+        }
+
+        if ($flags & static::ENV_ALL) {
+            foreach ($_ENV as $k => $v) {
+                if (array_key_exists($k, $this->env) && $this->env[$k] !== '') {
+                    continue;
+                }
+
+                $this->set($k, $v);
+            }
+        }
+
+        if ($flags & static::SERVER_ALL) {
+            foreach ($_SERVER as $k => $v) {
+                if (array_key_exists($k, $this->env) && $this->env[$k] !== '') {
+                    continue;
+                }
+
+                $this->set($k, $v);
+            }
+        }
     }
 
     /**
@@ -516,6 +550,24 @@ class Environment
                     $value = $this->convertType($_SERVER[$k]);
                     $this->set($k, $value);
                 }
+            }
+        }
+
+        if ($flags & static::GETENV_ALL) {
+            foreach (\getenv() as $k => $v) {
+                $this->set($k, $v);
+            }
+        }
+
+        if ($flags & static::ENV_ALL) {
+            foreach ($_ENV as $k => $v) {
+                $this->set($k, $v);
+            }
+        }
+
+        if ($flags & static::SERVER_ALL) {
+            foreach ($_SERVER as $k => $v) {
+                $this->set($k, $v);
             }
         }
     }

--- a/tests/complete.env
+++ b/tests/complete.env
@@ -1,3 +1,4 @@
+GITHUB=github-action
 TRAVIS=
 FROM_ENV=
 FROM_SERVER=


### PR DESCRIPTION
## Description
Because of Docker integration and practices in the open source community,
people want to import all env values even if there are not defined in .env file.

## Changelist
* add Environment::GETENV_ALL
* add Environment::ENV_ALL
* add Environment::SERVER_ALL
* update complete and override functions
* update README
* update tests